### PR TITLE
Fix CI: Include test files in repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ Thumbs.db
 
 # Plugin development
 /test/
-/spec/
 /coverage/
 
 # Local development configuration

--- a/spec/compiler_spec.lua
+++ b/spec/compiler_spec.lua
@@ -1,0 +1,151 @@
+local helpers = require("helpers")
+
+describe("typstwriter compiler", function()
+  local compiler
+
+  before_each(function()
+    helpers.mock_vim()
+
+    -- Mock the config module
+    package.loaded["typstwriter.config"] = {
+      get = function(key)
+        if key == "auto_compile" then
+          return false
+        end
+        if key == "open_after_compile" then
+          return false
+        end
+        if key == "notifications" then
+          return true
+        end
+        return nil
+      end,
+      should_notify = function()
+        return true
+      end,
+      get_notification_level = function()
+        return vim.log.levels.INFO
+      end,
+    }
+
+    compiler = require("typstwriter.compiler")
+  end)
+
+  after_each(function()
+    helpers.cleanup()
+  end)
+
+  describe("compile_current", function()
+    it("should compile typst file to PDF", function()
+      local system_commands = {}
+
+      -- Mock vim.fn.system
+      vim.fn.system = function(cmd)
+        table.insert(system_commands, cmd)
+        return "Success"
+      end
+
+      -- Mock vim.v.shell_error
+      vim.v.shell_error = 0
+
+      -- Mock file functions
+      vim.fn.expand = function(pattern)
+        if pattern == "%:e" then
+          return "typ"
+        end
+        if pattern == "%:p" then
+          return "/tmp/test.typ"
+        end
+        return pattern
+      end
+
+      vim.fn.filereadable = function()
+        return 1
+      end
+      vim.fn.executable = function()
+        return 1
+      end
+
+      local success = compiler.compile_current("/tmp/test.typ")
+
+      assert.is_true(success)
+      assert.equals(1, #system_commands)
+      assert.is_not_nil(system_commands[1]:match("typst compile.*test.typ"))
+    end)
+
+    it("should handle compilation errors", function()
+      local error_messages = {}
+
+      -- Mock vim.fn.system to fail
+      vim.fn.system = function(cmd)
+        return "Error: syntax error on line 10"
+      end
+
+      -- Mock vim.v.shell_error to indicate failure
+      vim.v.shell_error = 1
+
+      -- Suppress print output during test
+      local original_print = _G.print
+      _G.print = function() end
+
+      vim.notify = function(msg, level)
+        if level >= vim.log.levels.ERROR then
+          table.insert(error_messages, msg)
+        end
+      end
+
+      -- Mock other required functions
+      vim.fn.expand = function(pattern)
+        if pattern == "%:e" then
+          return "typ"
+        end
+        if pattern == "%:p" then
+          return "/tmp/test.typ"
+        end
+        return pattern
+      end
+
+      vim.fn.filereadable = function()
+        return 1
+      end
+      vim.fn.executable = function()
+        return 1
+      end
+
+      local success = compiler.compile_current("/tmp/test.typ")
+
+      -- Restore original print function
+      _G.print = original_print
+
+      assert.is_false(success)
+      assert.equals(1, #error_messages)
+    end)
+
+    it("should reject non-typst files", function()
+      local error_messages = {}
+
+      vim.notify = function(msg, level)
+        if level >= vim.log.levels.WARN then
+          table.insert(error_messages, msg)
+        end
+      end
+
+      -- Mock file functions to return non-typ extension
+      vim.fn.expand = function(pattern)
+        if pattern == "%:e" then
+          return "txt"
+        end
+        if pattern == "%:p" then
+          return "/tmp/test.txt"
+        end
+        return pattern
+      end
+
+      local success = compiler.compile_current("/tmp/test.txt")
+
+      assert.is_false(success)
+      assert.equals(1, #error_messages)
+      assert.is_not_nil(error_messages[1]:match("Not a Typst file"))
+    end)
+  end)
+end)

--- a/spec/config_spec.lua
+++ b/spec/config_spec.lua
@@ -1,0 +1,131 @@
+local helpers = require("helpers")
+
+describe("typstwriter config", function()
+  local config
+
+  before_each(function()
+    helpers.mock_vim()
+    config = require("typstwriter.config")
+  end)
+
+  after_each(function()
+    helpers.cleanup()
+  end)
+
+  describe("default configuration", function()
+    it("should have sensible defaults", function()
+      assert.is_not_nil(config.defaults)
+      assert.equals("/tmp/test/Documents/notes", config.defaults.notes_dir)
+      assert.equals("{name}.{code}.typ", config.defaults.filename_format)
+      assert.equals(6, config.defaults.code_length)
+      assert.is_false(config.defaults.auto_compile)
+      assert.is_true(config.defaults.open_after_compile)
+    end)
+  end)
+
+  describe("setup", function()
+    it("should merge user config with defaults", function()
+      local user_config = {
+        notes_dir = "~/custom-notes",
+        auto_compile = true,
+        code_length = 8,
+      }
+
+      config.setup(user_config)
+
+      assert.equals("/tmp/test/custom-notes", config.current.notes_dir)
+      assert.is_true(config.current.auto_compile)
+      assert.equals(8, config.current.code_length)
+      -- Should keep other defaults
+      assert.equals("{name}.{code}.typ", config.current.filename_format)
+    end)
+
+    it("should set template_dir default if not provided", function()
+      config.setup({ notes_dir = "~/test" })
+
+      assert.equals("/tmp/test/test/typst-templates", config.current.template_dir)
+    end)
+
+    it("should expand paths", function()
+      config.setup({
+        notes_dir = "~/notes",
+        template_dir = "~/templates",
+      })
+
+      assert.equals("/tmp/test/notes", config.current.notes_dir)
+      assert.equals("/tmp/test/templates", config.current.template_dir)
+    end)
+  end)
+
+  describe("get", function()
+    before_each(function()
+      config.setup({
+        auto_compile = true,
+        notifications = {
+          enabled = false,
+          level = 4,
+        },
+      })
+    end)
+
+    it("should get simple config values", function()
+      assert.is_true(config.get("auto_compile"))
+      assert.equals(6, config.get("code_length")) -- default
+    end)
+
+    it("should get nested config values with dot notation", function()
+      assert.is_false(config.get("notifications.enabled"))
+      assert.equals(4, config.get("notifications.level"))
+    end)
+
+    it("should return nil for non-existent keys", function()
+      assert.is_nil(config.get("non_existent"))
+      assert.is_nil(config.get("notifications.non_existent"))
+    end)
+  end)
+
+  describe("validation", function()
+    it("should validate filename format contains {name}", function()
+      local notify_called = false
+      vim.notify = function(msg, level)
+        if msg:match("filename_format.*{name}") then
+          notify_called = true
+        end
+      end
+
+      config.setup({ filename_format = "invalid-format" })
+
+      assert.is_true(notify_called)
+      assert.equals("{name}.{code}.typ", config.current.filename_format) -- Should reset to default
+    end)
+
+    it("should validate code_length range", function()
+      local notify_called = false
+      vim.notify = function(msg, level)
+        if msg:match("code_length.*between 1 and 20") then
+          notify_called = true
+        end
+      end
+
+      config.setup({ code_length = 25 })
+
+      assert.is_true(notify_called)
+      assert.equals(6, config.current.code_length) -- Should reset to default
+    end)
+  end)
+
+  describe("helper functions", function()
+    it("should_notify should return notifications.enabled value", function()
+      config.setup({ notifications = { enabled = true } })
+      assert.is_true(config.should_notify())
+
+      config.setup({ notifications = { enabled = false } })
+      assert.is_false(config.should_notify())
+    end)
+
+    it("get_notification_level should return notifications.level value", function()
+      config.setup({ notifications = { level = 4 } })
+      assert.equals(4, config.get_notification_level())
+    end)
+  end)
+end)

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -1,0 +1,167 @@
+-- Test helpers for typstwriter.nvim
+local helpers = {}
+
+-- Mock vim global for testing
+helpers.mock_vim = function()
+  local mock = {
+    fn = {
+      expand = function(path)
+        if path:match("^~/") then
+          return "/tmp/test" .. path:sub(2)
+        end
+        return path
+      end,
+      isdirectory = function()
+        return 1
+      end,
+      mkdir = function()
+        return 1
+      end,
+      glob = function()
+        return {}
+      end,
+      fnamemodify = function(path, modifier)
+        if modifier == ":t:r" then
+          return path:match("([^/]+)%.") or path
+        end
+        return path
+      end,
+      filereadable = function()
+        return 1
+      end,
+      getftime = function()
+        return os.time()
+      end,
+      executable = function()
+        return 1
+      end,
+      system = function()
+        return ""
+      end,
+      jobstart = function()
+        return 1
+      end,
+      has = function(feature)
+        -- Mock common vim features
+        if feature == "nvim-0.5" or feature == "nvim" then
+          return 1
+        elseif feature == "unix" then
+          return 1 -- Mock as unix system
+        elseif feature == "mac" or feature == "win32" then
+          return 0
+        end
+        return 0
+      end,
+      confirm = function(msg, choices, default)
+        return default or 1
+      end,
+    },
+    has = function(feature)
+      -- Mock common vim features
+      if feature == "nvim-0.5" or feature == "nvim" then
+        return 1
+      elseif feature == "unix" then
+        return 1 -- Mock as unix system
+      elseif feature == "mac" or feature == "win32" then
+        return 0
+      end
+      return 0
+    end,
+    cmd = function(command)
+      -- Mock vim commands
+    end,
+    api = {
+      nvim_create_user_command = function() end,
+      nvim_create_autocmd = function()
+        return 1
+      end,
+      nvim_create_augroup = function()
+        return 1
+      end,
+    },
+    keymap = {
+      set = function() end,
+    },
+    log = {
+      levels = {
+        INFO = 2,
+        WARN = 3,
+        ERROR = 4,
+      },
+    },
+    notify = function() end,
+    tbl_deep_extend = function(behavior, ...)
+      local result = {}
+      for _, tbl in ipairs({ ... }) do
+        for k, v in pairs(tbl) do
+          result[k] = v
+        end
+      end
+      return result
+    end,
+    split = function(str, sep)
+      local result = {}
+      for part in str:gmatch("([^" .. sep .. "]+)") do
+        table.insert(result, part)
+      end
+      return result
+    end,
+    ui = {
+      select = function(items, opts, callback)
+        if callback then
+          callback(items[1])
+        end
+      end,
+      input = function(opts, callback)
+        if callback then
+          callback("test")
+        end
+      end,
+    },
+    defer_fn = function(fn, delay)
+      fn()
+    end,
+    v = { shell_error = 0 },
+  }
+
+  -- Make vim global available
+  _G.vim = mock
+  return mock
+end
+
+-- Clean up after test
+helpers.cleanup = function()
+  _G.vim = nil
+  package.loaded["typstwriter"] = nil
+  package.loaded["typstwriter.config"] = nil
+  package.loaded["typstwriter.utils"] = nil
+  package.loaded["typstwriter.templates"] = nil
+  package.loaded["typstwriter.compiler"] = nil
+end
+
+-- Create temporary test files
+helpers.create_test_template = function(name, content)
+  content = content
+    or [[
+#import "typst-templates/base.typ": base
+
+#show: base.with(
+  title: "Test Template",
+  date: datetime.today(),
+  doc_type: "test",
+  status: "draft",
+  tags: ("test",),
+  properties: (
+    ("Author", "Test"),
+  ),
+)
+
+= Test Content
+This is a test template.
+]]
+  -- In real tests, this would create actual files
+  -- For now, we'll just return the content
+  return content
+end
+
+return helpers

--- a/spec/init_spec.lua
+++ b/spec/init_spec.lua
@@ -1,0 +1,164 @@
+local helpers = require("helpers")
+
+describe("typstwriter plugin", function()
+  local typstwriter
+
+  before_each(function()
+    helpers.mock_vim()
+
+    -- Mock the config module
+    package.loaded["typstwriter.config"] = {
+      get = function(key)
+        return nil
+      end,
+      should_notify = function()
+        return true
+      end,
+      get_notification_level = function()
+        return vim.log.levels.INFO
+      end,
+      setup = function() end,
+      current = { -- Mock current config table
+        notes_dir = "~/typstwriter",
+        template_dir = "~/typstwriter/templates",
+        filename_format = "{name}-{code}",
+      },
+    }
+
+    typstwriter = require("typstwriter")
+  end)
+
+  after_each(function()
+    helpers.cleanup()
+  end)
+
+  describe("plugin structure", function()
+    it("should expose main API", function()
+      assert.is_not_nil(typstwriter.setup)
+      assert.is_function(typstwriter.setup)
+      assert.is_not_nil(typstwriter.create_commands)
+      assert.is_not_nil(typstwriter.setup_keymaps)
+    end)
+
+    it("should expose submodules", function()
+      assert.is_not_nil(typstwriter.config)
+      assert.is_not_nil(typstwriter.utils)
+      assert.is_not_nil(typstwriter.templates)
+      assert.is_not_nil(typstwriter.compiler)
+    end)
+  end)
+
+  describe("setup", function()
+    it("should initialize plugin without errors", function()
+      local commands_created = false
+      local keymaps_setup = false
+      local autocommands_setup = false
+      local requirements_checked = false
+
+      -- Mock the internal functions
+      typstwriter.create_commands = function()
+        commands_created = true
+      end
+
+      typstwriter.setup_keymaps = function()
+        keymaps_setup = true
+      end
+
+      typstwriter.setup_autocommands = function()
+        autocommands_setup = true
+      end
+
+      typstwriter.check_requirements = function()
+        requirements_checked = true
+      end
+
+      -- Call setup
+      typstwriter.setup({ notes_dir = "~/test-notes" })
+
+      -- Verify all initialization steps were called
+      assert.is_true(commands_created)
+      assert.is_true(keymaps_setup)
+      assert.is_true(autocommands_setup)
+      assert.is_true(requirements_checked)
+    end)
+  end)
+
+  describe("create_commands", function()
+    it("should create all required user commands", function()
+      local commands_created = {}
+
+      vim.api.nvim_create_user_command = function(name, fn, opts)
+        commands_created[name] = { fn = fn, opts = opts }
+      end
+
+      typstwriter.create_commands()
+
+      -- Check all commands were created
+      local expected_commands = {
+        "TWriterNew",
+        "TWriterCompile",
+        "TWriterOpen",
+        "TWriterBoth",
+        "TWriterStatus",
+        "TWriterTemplates",
+      }
+
+      for _, cmd in ipairs(expected_commands) do
+        assert.is_not_nil(commands_created[cmd], "Command " .. cmd .. " was not created")
+        assert.is_function(commands_created[cmd].fn)
+        assert.is_not_nil(commands_created[cmd].opts.desc)
+      end
+    end)
+  end)
+
+  describe("info", function()
+    it("should return plugin information", function()
+      local info = typstwriter.info()
+
+      assert.is_table(info)
+      assert.equals("typstwriter.nvim", info.name)
+      assert.equals("1.0.0", info.version)
+      assert.is_string(info.description)
+      assert.equals("gl1tchc0d3r", info.author)
+      assert.is_table(info.config)
+      assert.is_table(info.requirements)
+    end)
+
+    it("should report system requirements", function()
+      local info = typstwriter.info()
+
+      assert.equals(">=0.7.0", info.requirements.neovim)
+      assert.is_boolean(info.requirements.typst)
+      assert.is_boolean(info.requirements.pdf_opener)
+    end)
+  end)
+
+  describe("requirements checking", function()
+    it("should check for typst binary", function()
+      local warnings = {}
+      vim.notify = function(msg, level)
+        if level >= vim.log.levels.WARN then
+          table.insert(warnings, msg)
+        end
+      end
+
+      -- Mock typst not available
+      local utils = require("typstwriter.utils")
+      utils.has_typst = function()
+        return false
+      end
+
+      typstwriter.check_requirements()
+
+      -- Should warn about missing typst
+      local found_typst_warning = false
+      for _, warning in ipairs(warnings) do
+        if warning:match("Typst binary not found") then
+          found_typst_warning = true
+          break
+        end
+      end
+      assert.is_true(found_typst_warning)
+    end)
+  end)
+end)

--- a/spec/integration_spec.lua
+++ b/spec/integration_spec.lua
@@ -1,0 +1,141 @@
+local helpers = require("helpers")
+
+describe("typstwriter integration", function()
+  local typstwriter
+
+  before_each(function()
+    helpers.mock_vim()
+    typstwriter = require("typstwriter")
+  end)
+
+  after_each(function()
+    helpers.cleanup()
+  end)
+
+  describe("plugin setup", function()
+    it("should setup without errors", function()
+      -- Mock vim.fn.has for PDF opener detection
+      vim.fn.has = function(feature)
+        if feature == "unix" then
+          return 1
+        end
+        return 0
+      end
+
+      assert.has_no_errors(function()
+        typstwriter.setup({
+          notes_dir = "~/test-notes",
+          auto_compile = false,
+        })
+      end)
+    end)
+
+    it("should create user commands", function()
+      local commands_created = {}
+
+      vim.api.nvim_create_user_command = function(name, fn, opts)
+        commands_created[name] = { fn = fn, opts = opts }
+      end
+
+      typstwriter.create_commands()
+
+      -- Verify main commands exist
+      assert.is_not_nil(commands_created.TWriterNew)
+      assert.is_not_nil(commands_created.TWriterCompile)
+      assert.is_not_nil(commands_created.TWriterOpen)
+      assert.is_not_nil(commands_created.TWriterBoth)
+    end)
+  end)
+
+  describe("core utilities", function()
+    it("should generate unique codes", function()
+      local utils = typstwriter.utils
+      local code1 = utils.generate_unique_code(8)
+      local code2 = utils.generate_unique_code(8)
+
+      assert.equals(8, #code1)
+      assert.equals(8, #code2)
+      assert.is_not_equal(code1, code2)
+    end)
+
+    it("should format filenames", function()
+      local utils = typstwriter.utils
+      local filename = utils.format_filename("test", "{name}-{code}.typ")
+
+      assert.is_string(filename)
+      assert.is_not_nil(filename:match("test%-[a-zA-Z0-9]+%.typ"))
+    end)
+
+    it("should check file existence", function()
+      local utils = typstwriter.utils
+
+      -- Mock vim.fn.filereadable for testing
+      vim.fn.filereadable = function(path)
+        return path == "/existing/file" and 1 or 0
+      end
+
+      assert.is_true(utils.file_exists("/existing/file"))
+      assert.is_false(utils.file_exists("/nonexistent/file"))
+    end)
+  end)
+
+  describe("compiler basic functionality", function()
+    it("should compile typst files", function()
+      local compiler = typstwriter.compiler
+      local system_commands = {}
+
+      -- Mock successful compilation
+      vim.fn.system = function(cmd)
+        table.insert(system_commands, cmd)
+        return "Success"
+      end
+      vim.v.shell_error = 0
+
+      -- Mock file checks
+      vim.fn.expand = function(pattern)
+        if pattern == "%:e" then
+          return "typ"
+        end
+        if pattern == "%:p" then
+          return "/test/file.typ"
+        end
+        return pattern
+      end
+      vim.fn.filereadable = function()
+        return 1
+      end
+      vim.fn.executable = function()
+        return 1
+      end
+
+      local success = compiler.compile_current("/test/file.typ")
+
+      assert.is_true(success)
+      assert.equals(1, #system_commands)
+      assert.is_not_nil(system_commands[1]:match("typst compile"))
+    end)
+  end)
+
+  describe("plugin info", function()
+    it("should provide plugin information", function()
+      -- Mock the PDF opener check to avoid errors
+      vim.fn.has = function(feature)
+        if feature == "unix" then
+          return 1
+        end
+        return 0
+      end
+      vim.fn.executable = function()
+        return 1
+      end
+
+      local info = typstwriter.info()
+
+      assert.equals("typstwriter.nvim", info.name)
+      assert.equals("1.0.0", info.version)
+      assert.equals("gl1tchc0d3r", info.author)
+      assert.is_table(info.config)
+      assert.is_table(info.requirements)
+    end)
+  end)
+end)

--- a/spec/templates_spec.lua
+++ b/spec/templates_spec.lua
@@ -1,0 +1,236 @@
+local helpers = require("helpers")
+
+describe("typstwriter templates", function()
+  local templates
+
+  before_each(function()
+    helpers.mock_vim()
+
+    -- Mock the config module
+    package.loaded["typstwriter.config"] = {
+      get = function(key)
+        if key == "template_dir" then
+          return "/test/templates"
+        end
+        if key == "notes_dir" then
+          return "/test/notes"
+        end
+        if key == "filename_format" then
+          return "{name}-{code}"
+        end
+        if key == "code_length" then
+          return 6
+        end
+        return nil
+      end,
+      should_notify = function()
+        return true
+      end,
+      get_notification_level = function()
+        return vim.log.levels.INFO
+      end,
+    }
+
+    templates = require("typstwriter.templates")
+  end)
+
+  after_each(function()
+    helpers.cleanup()
+  end)
+
+  describe("get_available_templates", function()
+    it("should return available templates", function()
+      local config = require("typstwriter.config")
+      config.get = function(key)
+        if key == "template_dir" then
+          return "/test/templates"
+        end
+        return nil
+      end
+
+      -- Mock directory exists
+      vim.fn.isdirectory = function()
+        return 1
+      end
+      -- Mock glob to return template files
+      vim.fn.glob = function(pattern)
+        return { "/test/templates/basic.typ", "/test/templates/academic.typ" }
+      end
+      -- Mock filename functions
+      vim.fn.fnamemodify = function(path, modifier)
+        if modifier == ":t" then
+          return path:match("/([^/]+)$")
+        elseif modifier == ":t:r" then
+          return path:match("/([^/]+)%.typ$")
+        end
+        return path
+      end
+
+      local available = templates.get_available_templates()
+      assert.is_table(available)
+      assert.is_not_nil(available.basic)
+      assert.is_not_nil(available.academic)
+      assert.equals("Basic template", available.basic.description)
+    end)
+  end)
+
+  describe("list_templates", function()
+    it("should return formatted template list", function()
+      local config = require("typstwriter.config")
+      config.get = function(key)
+        if key == "template_dir" then
+          return "/test/templates"
+        end
+        return nil
+      end
+
+      -- Mock directory exists
+      vim.fn.isdirectory = function()
+        return 1
+      end
+      -- Mock glob to return template files
+      vim.fn.glob = function(pattern)
+        return { "/test/templates/basic.typ", "/test/templates/academic.typ" }
+      end
+      -- Mock filename functions
+      vim.fn.fnamemodify = function(path, modifier)
+        if modifier == ":t" then
+          return path:match("/([^/]+)$")
+        elseif modifier == ":t:r" then
+          return path:match("/([^/]+)%.typ$")
+        end
+        return path
+      end
+
+      local template_list = templates.list_templates()
+
+      assert.is_table(template_list)
+      assert.equals(2, #template_list)
+      -- Should be a sorted array of template info objects
+      assert.is_string(template_list[1].name)
+      assert.is_string(template_list[1].description)
+    end)
+  end)
+
+  describe("create_document", function()
+    it("should create document from template", function()
+      local config = require("typstwriter.config")
+      config.get = function(key)
+        if key == "template_dir" then
+          return "/test/templates"
+        elseif key == "notes_dir" then
+          return "/test/notes"
+        elseif key == "filename_format" then
+          return "{name}-{code}"
+        elseif key == "code_length" then
+          return 6
+        end
+        return nil
+      end
+
+      -- Mock directory exists and template files
+      vim.fn.isdirectory = function()
+        return 1
+      end
+      vim.fn.glob = function()
+        return { "/test/templates/basic.typ" }
+      end
+      vim.fn.fnamemodify = function(path, modifier)
+        if modifier == ":t" then
+          return "basic.typ"
+        end
+        if modifier == ":t:r" then
+          return "basic"
+        end
+        return path
+      end
+      vim.fn.filereadable = function(filepath)
+        -- Template file exists, but new file doesn't exist yet
+        if filepath:match("templates.*basic%.typ$") then
+          return 1 -- Template exists
+        end
+        return 0 -- New file doesn't exist
+      end
+      vim.fn.confirm = function(msg, choices, default)
+        return 1 -- Always confirm "Yes" for overwrite
+      end
+      vim.fn.system = function()
+        return ""
+      end
+      vim.v.shell_error = 0
+      vim.cmd = function() end
+
+      -- Add debug mocking to track what's happening
+      local notify_messages = {}
+      vim.notify = function(msg, level)
+        table.insert(notify_messages, { msg = msg, level = level })
+      end
+
+      local success = templates.create_document("basic", "test-doc")
+
+      -- Debug: print all notify messages if test fails
+      if not success then
+        for _, msg in ipairs(notify_messages) do
+          print("Notify:", msg.msg, "Level:", msg.level)
+        end
+      end
+
+      assert.is_true(success)
+    end)
+  end)
+
+  describe("create_from_template", function()
+    it("should check for typst binary", function()
+      local error_messages = {}
+      vim.notify = function(msg, level)
+        if level >= vim.log.levels.ERROR then
+          table.insert(error_messages, msg)
+        end
+      end
+      vim.fn.executable = function()
+        return 0
+      end -- Typst not found
+      templates.create_from_template()
+      assert.equals(1, #error_messages)
+      assert.is_not_nil(error_messages[1]:match("Typst binary not found"))
+    end)
+  end)
+
+  describe("show_templates", function()
+    it("should display template information", function()
+      local config = require("typstwriter.config")
+      config.get = function(key)
+        if key == "template_dir" then
+          return "/test/templates"
+        end
+        return nil
+      end
+
+      -- Mock directory exists and has templates
+      vim.fn.isdirectory = function()
+        return 1
+      end
+      vim.fn.glob = function()
+        return { "/test/templates/basic.typ" }
+      end
+      vim.fn.fnamemodify = function(path, modifier)
+        if modifier == ":t" then
+          return "basic.typ"
+        end
+        if modifier == ":t:r" then
+          return "basic"
+        end
+        return path
+      end
+      local printed = {}
+      _G.print = function(msg)
+        table.insert(printed, msg or "")
+      end
+      templates.show_templates()
+      -- Should print headers and template info
+      assert.is_true(#printed > 0)
+      local output = table.concat(printed, "\n")
+      assert.is_not_nil(output:match("Available templates"))
+    end)
+  end)
+end)

--- a/spec/utils_spec.lua
+++ b/spec/utils_spec.lua
@@ -1,0 +1,195 @@
+local helpers = require("helpers")
+
+describe("typstwriter utils", function()
+  local utils, config
+
+  before_each(function()
+    helpers.mock_vim()
+
+    -- Mock the config module
+    package.loaded["typstwriter.config"] = {
+      get = function(key)
+        if key == "code_length" then
+          return 6
+        end
+        if key == "filename_format" then
+          return "{name}-{code}"
+        end
+        if key == "use_modern_ui" then
+          return true
+        end
+        if key == "notifications" then
+          return true
+        end
+        return nil
+      end,
+      should_notify = function()
+        return true
+      end,
+      get_notification_level = function()
+        return vim.log.levels.INFO
+      end,
+      setup = function() end,
+    }
+
+    utils = require("typstwriter.utils")
+  end)
+
+  after_each(function()
+    helpers.cleanup()
+  end)
+
+  describe("generate_unique_code", function()
+    it("should generate code of default length", function()
+      local code = utils.generate_unique_code()
+      assert.equals(6, #code) -- default length
+    end)
+
+    it("should generate code of specified length", function()
+      local code = utils.generate_unique_code(10)
+      assert.equals(10, #code)
+    end)
+
+    it("should generate different codes on subsequent calls", function()
+      local code1 = utils.generate_unique_code()
+      local code2 = utils.generate_unique_code()
+      assert.is_not_equal(code1, code2)
+    end)
+
+    it("should only contain alphanumeric characters", function()
+      local code = utils.generate_unique_code(100) -- Large sample
+      assert.is_true(code:match("^[a-zA-Z0-9]+$") ~= nil)
+    end)
+  end)
+
+  describe("format_filename", function()
+    it("should replace {name} placeholder", function()
+      local filename = utils.format_filename("test-doc")
+      assert.is_string(filename)
+      assert.is_not_nil(filename:match("test%-doc"))
+    end)
+
+    it("should replace {date} placeholder", function()
+      local filename = utils.format_filename("test", "{name}-{date}.typ")
+      assert.is_string(filename)
+      assert.is_not_nil(filename:match("test%-2025")) -- assuming current year
+    end)
+
+    it("should replace {code} placeholder", function()
+      local filename = utils.format_filename("test", "{name}-{code}.typ")
+      assert.is_string(filename)
+      assert.is_not_nil(filename:match("test%-[a-zA-Z0-9]+"))
+    end)
+
+    it("should ensure .typ extension", function()
+      local filename1 = utils.format_filename("test", "{name}")
+      assert.is_true(filename1:match("%.typ$") ~= nil)
+
+      local filename2 = utils.format_filename("test", "{name}.typ")
+      assert.equals(1, select(2, filename2:gsub("%.typ", ""))) -- Should only appear once
+    end)
+  end)
+
+  describe("file operations", function()
+    it("file_exists should return true for readable files", function()
+      assert.is_true(utils.file_exists("/some/path"))
+    end)
+
+    it("dir_exists should return true for directories", function()
+      assert.is_true(utils.dir_exists("/some/dir"))
+    end)
+
+    it("get_pdf_path should convert .typ to .pdf", function()
+      -- Mock vim.fn.fnamemodify to simulate the actual behavior
+      vim.fn.fnamemodify = function(path, modifier)
+        if modifier == ":r" then
+          return path:gsub("%.typ$", "")
+        end
+        return path
+      end
+
+      local pdf_path = utils.get_pdf_path("/path/to/document.typ")
+      assert.equals("/path/to/document.pdf", pdf_path)
+    end)
+  end)
+
+  describe("system utilities", function()
+    it("has_typst should check for typst executable", function()
+      assert.is_true(utils.has_typst()) -- Mocked to return true
+    end)
+
+    it("get_pdf_opener should return appropriate opener", function()
+      local opener = utils.get_pdf_opener()
+      assert.is_not_nil(opener)
+    end)
+
+    it("system_exec should execute commands", function()
+      local success = utils.system_exec("echo test", "Success", "Error")
+      assert.is_true(success)
+    end)
+  end)
+
+  describe("UI utilities", function()
+    it("use_modern_ui should return true when vim.ui is available", function()
+      local result = utils.use_modern_ui()
+      assert.is_truthy(result) -- Should return a truthy value when all conditions are met
+    end)
+
+    it("select should call callback with selection", function()
+      local selected = nil
+      utils.select({ "option1", "option2" }, {}, function(choice)
+        selected = choice
+      end)
+      assert.equals("option1", selected)
+    end)
+
+    it("input should call callback with input", function()
+      local input_result = nil
+      utils.input({ prompt = "Test:" }, function(result)
+        input_result = result
+      end)
+      assert.equals("test", input_result)
+    end)
+  end)
+
+  describe("string utilities", function()
+    it("capitalize should capitalize first letter", function()
+      assert.equals("Hello", utils.capitalize("hello"))
+      assert.equals("HELLO", utils.capitalize("hELLO"))
+      assert.equals("", utils.capitalize(""))
+      assert.equals("A", utils.capitalize("a"))
+    end)
+  end)
+
+  describe("notify", function()
+    it("should call vim.notify when notifications enabled", function()
+      local notify_called = false
+      local notify_message = nil
+      vim.notify = function(msg, level)
+        notify_called = true
+        notify_message = msg
+      end
+
+      utils.notify("test message")
+
+      assert.is_true(notify_called)
+      assert.equals("test message", notify_message)
+    end)
+
+    it("should not call vim.notify when notifications disabled", function()
+      -- Override config to disable notifications
+      package.loaded["typstwriter.config"].should_notify = function()
+        return false
+      end
+
+      local notify_called = false
+      vim.notify = function(msg, level)
+        notify_called = true
+      end
+
+      utils.notify("test message")
+
+      assert.is_false(notify_called)
+    end)
+  end)
+end)


### PR DESCRIPTION
This PR fixes the CI pipeline failures by including the test files in the repository.

## Problem
The CI was failing because:
- \`/spec/\` directory was in \`.gitignore\`
- Test files weren't available in CI environment
- \`luacheck\` and \`stylua\` commands failed when trying to process \`spec/\` directory
- CI jobs were showing: \`spec/: couldn't read: No such file or directory\`

## Solution
- ✅ **Remove \`/spec/\` from \`.gitignore\`** 
- ✅ **Include comprehensive test suite** (7 test files, ~30k total code)
- ✅ **Keep \`/test/\` and \`/coverage/\` ignored** (for different use cases and generated output)

## Test Files Included
- \`compiler_spec.lua\` (3.6k) - Compiler functionality tests  
- \`config_spec.lua\` (4.0k) - Configuration validation tests
- \`helpers.lua\` (3.7k) - Test helper utilities
- \`init_spec.lua\` (4.5k) - Plugin initialization tests
- \`integration_spec.lua\` (3.8k) - Integration test suite  
- \`templates_spec.lua\` (6.7k) - Template system tests
- \`utils_spec.lua\` (5.9k) - Utility function tests

## Expected CI Improvements
- ✅ Linting will succeed (\`luacheck\` can process \`spec/\` files)
- ✅ Format checking will succeed (\`stylua\` can check \`spec/\` files) 
- ✅ Tests can run with \`busted\` using existing test files
- ✅ Coverage reports will be more comprehensive

This should resolve all CI pipeline failures and enable proper testing infrastructure.