### PR TITLE
fix: Replace rhymond/setup-neovim with manual Neovim installation (#5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,19 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Setup Neovim
-      uses: rhymond/setup-neovim@v1
-      with:
-        neovim-version: ${{ matrix.neovim-version }}
+    - name: Setup Neovim ${{ matrix.neovim-version }}
+      run: |
+        if [ "${{ matrix.neovim-version }}" = "stable" ]; then
+          curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
+          tar -xzf nvim-linux-x86_64.tar.gz
+          sudo mv nvim-linux-x86_64 /opt/nvim
+        else
+          curl -LO https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-x86_64.tar.gz
+          tar -xzf nvim-linux-x86_64.tar.gz
+          sudo mv nvim-linux-x86_64 /opt/nvim
+        fi
+        sudo ln -sf /opt/nvim/bin/nvim /usr/local/bin/nvim
+        nvim --version
     
     - name: Setup Lua
       uses: leafo/gh-actions-lua@v10
@@ -44,7 +53,7 @@ jobs:
       run: make test-coverage
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./luacov.report.out
         flags: unittests
@@ -100,10 +109,13 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Setup Neovim
-      uses: rhymond/setup-neovim@v1
-      with:
-        neovim-version: 'stable'
+    - name: Setup Neovim (stable)
+      run: |
+        curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
+        tar -xzf nvim-linux-x86_64.tar.gz
+        sudo mv nvim-linux-x86_64 /opt/nvim
+        sudo ln -sf /opt/nvim/bin/nvim /usr/local/bin/nvim
+        nvim --version
     
     - name: Setup Lua
       uses: leafo/gh-actions-lua@v10
@@ -133,7 +145,7 @@ jobs:
       run: make ci
     
     - name: Upload coverage from CI pipeline
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         file: ./luacov.report.out
         flags: ci-pipeline


### PR DESCRIPTION
* Fix CI: Include test files in repository

- Remove /spec/ from .gitignore to enable test files in CI/CD pipeline
- Spec directory contains comprehensive test suite with 7 test files
- Keep /test/ and /coverage/ ignored as intended (for different use cases)
- This resolves CI failures where luacheck and stylua couldn't find spec/ directory

Test files included:
- compiler_spec.lua (3.6k) - Compiler functionality tests  
- config_spec.lua (4.0k) - Configuration validation tests
- helpers.lua (3.7k) - Test helper utilities
- init_spec.lua (4.5k) - Plugin initialization tests
- integration_spec.lua (3.8k) - Integration test suite  
- templates_spec.lua (6.7k) - Template system tests
- utils_spec.lua (5.9k) - Utility function tests

Fixes GitHub Actions CI pipeline failures in lint and format-check jobs.

* fix: Replace rhymond/setup-neovim with manual Neovim installation

- Remove dependency on unavailable rhymond/setup-neovim action
- Use direct download from Neovim releases for both stable and nightly
- Update codecov action to v4 for better compatibility
- Ensure consistent Neovim installation across all CI jobs

This resolves the 'Unable to resolve action rhymond/setup-neovim, repository not found' error that was causing all CI runs to fail.

* fix: Correct Neovim download filenames in CI

Use nvim-linux-x86_64.tar.gz instead of nvim-linux64.tar.gz to match the actual release artifacts from neovim/neovim repository.

The previous URLs were returning 404 errors causing tar extraction to fail with 'not in gzip format' error.