### PR TITLE
feat: Add human.typ template for documenting people profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,7 @@ Templates should be `.typ` files in your template directory. The plugin:
 typst-templates/
 ├── base.typ       # Shared styles and utilities (ignored by plugin)
 ├── meeting.typ    # Meeting notes template
+├── human.typ      # Human profile template for documenting people
 ├── project.typ    # Project documentation template
 ├── article.typ    # Article template
 └── report.typ     # Report template


### PR DESCRIPTION
This PR adds a new human.typ template that allows users to create structured documents for documenting people and their information.

**Features:**
- Comprehensive human profile template with sections for:
  - Professional information (role, organization, contact details)
  - Background and experience
  - Skills and expertise
  - Communication preferences and availability
  - Collaboration notes and working style
  - Personal interests for building rapport
  - Meeting history tracking
  - References and links

**Documentation:**
- Updated README.md to include the human template in the example template directory
- Template follows existing conventions and uses the base.typ system
- Automatic template discovery will pick up the new template

**Use Cases:**
- Maintaining contact information for professional networks
- Documenting team members and collaborators
- Creating reference profiles that can be linked from other documents
- Building a personal knowledge base of important people

This template supports the plugin's vision of comprehensive knowledge management while staying true to the terminal-native, keyboard-driven philosophy.